### PR TITLE
Fix players API response shape

### DIFF
--- a/scripts/ingestPlayers.js
+++ b/scripts/ingestPlayers.js
@@ -196,7 +196,8 @@ async function ingestAllPlayers() {
   console.log('\n🔍 Testing database...');
   try {
     const testResponse = await fetch(`${API_BASE_URL}/api/players?limit=5`);
-    const testPlayers = await testResponse.json();
+    const testData = await testResponse.json();
+    const testPlayers = testData.players || [];
     console.log('Sample players in database:');
     testPlayers.forEach(p => {
       console.log(`  - ${p.name} (${p.position}, ${p.team})`);

--- a/server/index.js
+++ b/server/index.js
@@ -141,7 +141,7 @@ app.get("/api/players", async (req, res) => {
     params.push(parseInt(limit));
 
     const result = await pool.query(query, params);
-    res.json(result.rows);
+    res.json({ players: result.rows });
   } catch (error) {
     console.error('Error fetching players:', error);
     res.status(500).json({ error: error.message });


### PR DESCRIPTION
## Summary
- wrap the /api/players response in a players object so the client can read the results
- update the ingest utility to read the wrapped response when sampling players

## Testing
- npm --prefix client run build

------
https://chatgpt.com/codex/tasks/task_e_68ca0f791c8083269648d3891154c8ef