### PR TITLE
fix(server): default to espn scraper mode

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -11,6 +11,25 @@ Configure the following variables before starting the server:
 | `DATABASE_URL` | ✅ | Postgres connection string used for roster and watchlist data. |
 | `SWID` | ✅ | ESPN authentication cookie value. Required for all authenticated ESPN API requests. |
 | `ESPN_S2` | ✅ | ESPN authentication cookie value paired with `SWID`. |
+| `USE_ESPN_SCRAPER` | ⛔️ | Defaults to `1` so routes proxy through the unofficial ESPN "LM API" host used by [ffscrapr](https://github.com/ffverse/ffscrapr). Set to `0` to fall back to the standard API host. |
+| `ESPN_SCRAPER_HOST` | ⛔️ | Override host for scraper mode (defaults to `https://lm-api-reads.fantasy.espn.com`). |
+
+### ESPN scraper mode
+
+Scraper mode is on by default so the server emulates the [`ffscrapr`](https://ffscrapr.ffverse.com/) workflow instead of calling the standard `fantasy.espn.com` API directly. To explicitly start the server in scraper mode (or to illustrate the default):
+
+```bash
+USE_ESPN_SCRAPER=1 node index.js
+```
+
+With scraper mode enabled the proxy swaps requests to `https://lm-api-reads.fantasy.espn.com`, forwards the same `x-fantasy-filter` headers, and sends a `User-Agent` matching the ffscrapr tooling. You can still provide `SWID`/`ESPN_S2` cookies (recommended for private leagues), but they are no longer mandatory for public data pulls.
+
+To opt out and hit the standard API host directly, set:
+
+```bash
+USE_ESPN_SCRAPER=0 node index.js
+```
+
 | `PORT` | ⛔️ | Optional port (defaults to `8081`). |
 | `USE_MOCK_WAIVER_DATA` | ⛔️ | When set to `1`, the waiver analysis endpoint uses built-in sample data. Helpful for local development or automated tests without ESPN access. |
 

--- a/server/src/env.ts
+++ b/server/src/env.ts
@@ -1,11 +1,35 @@
 import 'dotenv/config';
 
-const env = {
-  SWID: process.env.SWID,
-  ESPN_S2: process.env.ESPN_S2,
+type EnvConfig = {
+  SWID?: string;
+  ESPN_S2?: string;
+  USE_ESPN_SCRAPER: boolean;
+  ESPN_SCRAPER_HOST: string;
 };
 
-if (!env.SWID || !env.ESPN_S2) {
+const resolveUseEspnScraper = (): boolean => {
+  const raw = process.env.USE_ESPN_SCRAPER;
+
+  if (!raw) {
+    return true;
+  }
+
+  const normalized = raw.toLowerCase();
+  if (normalized === '0' || normalized === 'false') {
+    return false;
+  }
+
+  return normalized === '1' || normalized === 'true';
+};
+
+const env: EnvConfig = {
+  USE_ESPN_SCRAPER: resolveUseEspnScraper(),
+  SWID: process.env.SWID,
+  ESPN_S2: process.env.ESPN_S2,
+  ESPN_SCRAPER_HOST: process.env.ESPN_SCRAPER_HOST ?? 'https://lm-api-reads.fantasy.espn.com',
+};
+
+if (!env.USE_ESPN_SCRAPER && (!env.SWID || !env.ESPN_S2)) {
   console.warn('[WARN] Missing SWID or ESPN_S2 env vars. Set them in your host.');
 }
 

--- a/server/src/routes/espn/client.ts
+++ b/server/src/routes/espn/client.ts
@@ -1,15 +1,71 @@
-import fetch from 'node-fetch';
+import fetch, { type RequestInit } from 'node-fetch';
 import env from '../../env';
 
 export type EspnFetchInit = {
   filter?: unknown;
   headers?: Record<string, string | undefined>;
+  method?: 'GET' | 'POST';
+  body?: unknown;
+};
+
+const SCRAPER_USER_AGENT = 'ffscrapr-node-proxy/1.0';
+
+const buildScraperUrl = (url: string): string => {
+  if (!env.USE_ESPN_SCRAPER) {
+    return url;
+  }
+
+  try {
+    const original = new URL(url);
+    const scraperBase = new URL(env.ESPN_SCRAPER_HOST);
+
+    if (original.hostname !== 'fantasy.espn.com') {
+      return url;
+    }
+
+    const basePath = scraperBase.pathname.replace(/\/$/, '');
+
+    original.protocol = scraperBase.protocol;
+    original.host = scraperBase.host;
+    original.port = scraperBase.port;
+    original.pathname = `${basePath}${original.pathname}`;
+
+    return original.toString();
+  } catch (error) {
+    console.warn('[WARN] Failed to transform ESPN URL for scraper mode:', error);
+    return url;
+  }
+};
+
+const serializeBody = (body: unknown): string | undefined => {
+  if (body === undefined) {
+    return undefined;
+  }
+
+  if (typeof body === 'string') {
+    return body;
+  }
+
+  return JSON.stringify(body);
 };
 
 export async function espnFetch<T = unknown>(url: string, init: EspnFetchInit = {}): Promise<T> {
+  const requestUrl = buildScraperUrl(url);
+
   const headers: Record<string, string> = {
-    Cookie: `SWID=${env.SWID ?? ''}; ESPN_S2=${env.ESPN_S2 ?? ''}`,
+    Accept: 'application/json',
   };
+
+  if (!env.USE_ESPN_SCRAPER) {
+    headers.Cookie = `SWID=${env.SWID ?? ''}; ESPN_S2=${env.ESPN_S2 ?? ''}`;
+  } else {
+    headers['User-Agent'] = SCRAPER_USER_AGENT;
+    headers['x-fantasy-platform'] = 'ffscrapr';
+
+    if (env.SWID && env.ESPN_S2) {
+      headers.Cookie = `SWID=${env.SWID}; ESPN_S2=${env.ESPN_S2}`;
+    }
+  }
 
   if (init.headers) {
     for (const [key, value] of Object.entries(init.headers)) {
@@ -23,7 +79,20 @@ export async function espnFetch<T = unknown>(url: string, init: EspnFetchInit = 
     headers['x-fantasy-filter'] = JSON.stringify(init.filter);
   }
 
-  const response = await fetch(url, { headers, method: 'GET' });
+  const requestInit: RequestInit = {
+    headers,
+    method: init.method ?? (init.body ? 'POST' : 'GET'),
+  };
+
+  const body = serializeBody(init.body);
+  if (body !== undefined) {
+    requestInit.body = body;
+    if (!headers['Content-Type']) {
+      headers['Content-Type'] = 'application/json';
+    }
+  }
+
+  const response = await fetch(requestUrl, requestInit);
   if (!response.ok) {
     const text = await response.text();
     throw new Error(`ESPN ${response.status}: ${text}`);


### PR DESCRIPTION
## Summary
- add environment flags to toggle an ESPN scraper host that mimics the ffscrapr workflow
- update the ESPN proxy client to rewrite URLs, user agent, and headers when scraper mode is enabled
- default the scraper mode flag to on so the scraper host is used first and document how to opt out

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68ca53c98e808326aeb8a52a9479d0d5